### PR TITLE
disp8/disp0 mem displacement encoding.

### DIFF
--- a/src/backend/target/x86/x86_asm.cpp
+++ b/src/backend/target/x86/x86_asm.cpp
@@ -50,17 +50,34 @@ namespace rat {
 
 	void Asm::modrmReg(U32 reg, U32 rm) { b((U8)(0xc0 | ((reg & 7) << 3) | (rm & 7))); }
 
+	// mod=00 carries no displacement, but base=101 means rip / no-base there, so
+	// rbp and r13 always need at least a disp8
+	U32 Asm::memMod(U32 base, I32 disp) {
+		if(disp == 0 && (base & 7) != 5)
+			return 0;
+		return disp == (I32)(I8)disp ? 1u : 2u;
+	}
+
+	void Asm::memDisp(U32 mod, I32 disp) {
+		if(mod == 1)
+			b((U8)disp);
+		else if(mod == 2)
+			d32((U32)disp);
+	}
+
 	void Asm::modrmMem(U32 reg, U32 base, I32 disp) {
-		b((U8)(0x80 | ((reg & 7) << 3) | (base & 7)));
+		U32 mod = memMod(base, disp);
+		b((U8)((mod << 6) | ((reg & 7) << 3) | (base & 7)));
 		if((base & 7) == 4)
 			b(0x24); // SIB: scale=0, index=none, base
-		d32((U32)disp);
+		memDisp(mod, disp);
 	}
 
 	void Asm::modrmMemSib(U32 reg, U32 base, U32 index, U32 scaleLog2, I32 disp) {
-		b((U8)(0x80 | ((reg & 7) << 3) | 4)); // rm=100 => SIB byte follows
+		U32 mod = memMod(base, disp);
+		b((U8)((mod << 6) | ((reg & 7) << 3) | 4)); // rm=100 => SIB byte follows
 		b((U8)(((scaleLog2 & 3) << 6) | ((index & 7) << 3) | (base & 7)));
-		d32((U32)disp);
+		memDisp(mod, disp);
 	}
 
 	void

--- a/src/backend/target/x86/x86_asm.h
+++ b/src/backend/target/x86/x86_asm.h
@@ -180,6 +180,9 @@ namespace rat {
 		void modrmMem(U32 reg, U32 base, I32 disp);
 		// [base + index*(1<<scaleLog2) + disp]
 		void modrmMemSib(U32 reg, U32 base, U32 index, U32 scaleLog2, I32 disp);
+		// narrowest mod field the displacement fits in, and its tail
+		static U32 memMod(U32 base, I32 disp);
+		void memDisp(U32 mod, I32 disp);
 
 		enum MemFlags : U8 {
 			kMemW = 1,				// REX.W


### PR DESCRIPTION
Encode memory displacements at their narrowest width, ~10% smaller .text, marginal perf improvements across suite. 